### PR TITLE
Add jquery to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Molire Production",
   "license": "ISC",
   "dependencies": {
-    "fullpage.js": "^2.9.2"
+    "fullpage.js": "^2.9.2",
+    "jquery": "^3.1.1"
   },
   "devDependencies": {
     "css-loader": "^0.26.1",


### PR DESCRIPTION
**Issue**

`jquery` library is not installed. It produces the error when running `npm start`: 
```
node_modules/jquery doesn't exist (module as directory)
``` 

**Fixes** 

- Added `jquery library to package.json`, so that it will be installed with `npm install`